### PR TITLE
Replaces hcl example in README.md with yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,28 @@ This action provides `flutter` for Github Actions.
 This example first fetches the dependencies with `flutter pub get` and then
 builds an apk and runs the flutter tests in parallel.
 
-```hcl
-workflow "build and test app" {
-  on = "push"
-  resolves = ["build apk", "run tests"]
-}
-
-# Install dependencies
-action "install dependencies" {
-  uses = "steebchen/flutter@master"
-  args = "pub get"
-}
-
-# test app
-action "run tests" {
-  needs = "install dependencies"
-  uses = "steebchen/flutter@master"
-  args = "test"
-}
-
-# Build APK
-action "build apk" {
-  needs = "install dependencies"
-  uses  = "steebchen/flutter@master"
-  args  = "build apk --release"
-}
+`.github/workflows/main.yml:`
+```yml
+on: push
+name: build and test app
+jobs:
+  installDependencies:
+    name: install dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: install dependencies
+      uses: steebchen/flutter@master
+      with:
+        args: pub get
+    - name: run tests
+      uses: steebchen/flutter@master
+      with:
+        args: test
+    - name: build apk
+      uses: steebchen/flutter@master
+      with:
+        args: build apk --release
 ```
 
 ![github actions preview](./preview.jpg)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ jobs:
     name: install dependencies
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
     - name: install dependencies
+      uses: actions/checkout@master
       uses: steebchen/flutter@master
       with:
         args: pub get

--- a/README.md
+++ b/README.md
@@ -30,5 +30,3 @@ jobs:
       with:
         args: build apk --release
 ```
-
-![github actions preview](./preview.jpg)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ builds an apk and runs the flutter tests in parallel.
 on: push
 name: build and test app
 jobs:
-  installDependencies:
+  build:
     name: install dependencies
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
HCL syntax in GitHub Actions will be deprecated on September 30, 2019
To avoid confusion I therefore replaced the example with the new yml syntax.
The yml has been generated with the [actions/migrate](https://github.com/actions/migrate) tool